### PR TITLE
Minor Adjustment Allows Hoppers to Extract Empty Buckets in the Input Slot from Freezers

### DIFF
--- a/common/src/main/java/com/unlikepaladin/pfm/blocks/blockentities/FreezerBlockEntity.java
+++ b/common/src/main/java/com/unlikepaladin/pfm/blocks/blockentities/FreezerBlockEntity.java
@@ -105,7 +105,7 @@ public class FreezerBlockEntity extends LockableContainerBlockEntity implements 
 
 
     private static final int[] TOP_SLOTS = new int[]{0};
-    private static final int[] BOTTOM_SLOTS = new int[]{2, 1};
+    private static final int[] BOTTOM_SLOTS = new int[]{2, 1, 0};
     private static final int[] SIDE_SLOTS = new int[]{1};
     private DefaultedList<ItemStack> inventory = DefaultedList.ofSize(size(), ItemStack.EMPTY);
     int fuelTime;
@@ -229,7 +229,7 @@ public class FreezerBlockEntity extends LockableContainerBlockEntity implements 
 
     @Override
     public boolean canExtract(int slot, ItemStack stack, Direction dir) {
-        if (dir == Direction.DOWN && slot == 1) {
+        if (dir == Direction.DOWN && slot != 2) {
             return stack.isOf(Items.BUCKET);
         }
         return true;


### PR DESCRIPTION
Currently, when a Freezer consumes a Water Bucket to produce Ice, the empty bucket remains in the Freezer's input slot. This empty bucket cannot be extracted by a Hopper placed beneath the Freezer, occupying the input slot until it is manually removed.

This pull request introduces a minor change to the Freezer's behavior, allowing Hoppers placed beneath the Freezer to extract empty buckets from the input slot. This change enables the creation of fully automated ice production setups using Freezers.