### PR TITLE
Revert "Minor Adjustment Allows Hoppers to Extract Empty Buckets in the Input Slot from Freezers"

### DIFF
--- a/common/src/main/java/com/unlikepaladin/pfm/blocks/blockentities/FreezerBlockEntity.java
+++ b/common/src/main/java/com/unlikepaladin/pfm/blocks/blockentities/FreezerBlockEntity.java
@@ -105,7 +105,7 @@ public class FreezerBlockEntity extends LockableContainerBlockEntity implements 
 
 
     private static final int[] TOP_SLOTS = new int[]{0};
-    private static final int[] BOTTOM_SLOTS = new int[]{2, 1, 0};
+    private static final int[] BOTTOM_SLOTS = new int[]{2, 1};
     private static final int[] SIDE_SLOTS = new int[]{1};
     private DefaultedList<ItemStack> inventory = DefaultedList.ofSize(size(), ItemStack.EMPTY);
     int fuelTime;
@@ -229,7 +229,7 @@ public class FreezerBlockEntity extends LockableContainerBlockEntity implements 
 
     @Override
     public boolean canExtract(int slot, ItemStack stack, Direction dir) {
-        if (dir == Direction.DOWN && slot != 2) {
+        if (dir == Direction.DOWN && slot == 1) {
             return stack.isOf(Items.BUCKET);
         }
         return true;


### PR DESCRIPTION
Reverts UnlikePaladin/paladins-furniture#128